### PR TITLE
Improve readability of the companies section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 static/feed.xml
+rss/target

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,14 +102,14 @@
           job openings.") }}
           <ul class="list-group list-group-flush">
             {% for company in companies %}
-            <div class="list-group-item">
+            <li class="list-group-item">
                 <div class="card-title">{{ company.name }}</div>
                 <a href="{{ company.link }}" class="card-link" target="_blank">Home</a>
                 {% for entry in company.entries | default(value=[]) %}
                 <a href="{{ entry.link }}" target="_blank" class="card-link">{{ entry.name }}</a>
                 {% endfor %}
-            </div>
-            {% endfor %}
+            </li>
+           {% endfor %}
           </ul>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,16 +102,13 @@
           job openings.") }}
           <ul class="list-group list-group-flush">
             {% for company in companies %}
-            <li class="list-group-item list-group-item-action">
-              <a href="{{ company.link }}" target="_blank">{{ company.name }}</a>
-              <ul class="list-group">
+            <div class="list-group-item">
+                <div class="card-title">{{ company.name }}</div>
+                <a href="{{ company.link }}" class="card-link" target="_blank">Home</a>
                 {% for entry in company.entries | default(value=[]) %}
-                <a href="{{ entry.link }}" target="_blank" class="list-group-item list-group-item-action">
-                  {{ entry.name }}
-                </a>
+                <a href="{{ entry.link }}" target="_blank" class="card-link">{{ entry.name }}</a>
                 {% endfor %}
-              </ul>
-            </li>
+            </div>
             {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
Just an attempt at improving the readability of the companies section. I did not want to interfere with the `simplelist` and `sectionheader` macros. Seemed like this simple change might do the trick.

Also i added `rss/target` to `.gitignore`, I hope you don't mind.

Btw, `zola` is great!