### PR TITLE
Fix copypaste error in Open Graph meta tags

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Index of events and links related to the Rust programming language in the Czech Republic.">
 
   <meta property="og:title" content="Czech Rust community index" />
-  <meta property="og:title" content="Index of events and links related to the Rust programming language in the Czech Republic." />
+  <meta property="og:description" content="Index of events and links related to the Rust programming language in the Czech Republic." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://rustlang.cz" />
   <meta property="og:image" content="https://rustlang.cz/img/ferris-cz.png" />


### PR DESCRIPTION
I discovered what appears to be a copypaste error in the Open Graph `meta` tags of the website. Has little impact probably, but as I was going through the sources I figured it would be best to let you know.