### PR TITLE
Add Rust Moravia meetup (September 2024)

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,3 +1,8 @@
+- name: "Rust Moravia Meetup (September 2024)"
+  link: https://www.meetup.com/rust-moravia/events/301360936/
+  date: "2024-09-18T17:30:00+02:00"
+  published: "2024-07-18T16:30:00+02:00"
+  city: Olomouc
 - name: "Prague Rust Meetup (July 2024)"
   link: https://www.meetup.com/rust-prague/events/301227195/
   date: "2024-07-11T18:00:00+02:00"


### PR DESCRIPTION
CC @marekpsenka

I also added this event to the [Rust community calendar](https://calendar.google.com/calendar/u/0/embed?showTitle=0&showPrint=0&showTabs=0&showCalendars=0&mode=AGENDA&height=400&wkst=1&bgcolor=%23FFFFFF&src=apd9vmbc22egenmtu5l6c5jbfc@group.calendar.google.com&color=%23691426&ctz=Europe/Madrid), so that it will appear in [This Week in Rust](https://this-week-in-rust.org/).