### PR TITLE
config.toml: Rename the `generate_feed` option to `generate_feeds`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,7 @@ compile_sass = true
 minify_html = true
 build_search_index = false
 
-generate_feed = true
+generate_feeds = true
 feed_limit = 50
 
 [markdown]


### PR DESCRIPTION
The `generate_feed` config option was renamed to `generate_feeds` [in Zola 0.19.0](https://github.com/getzola/zola/blob/master/CHANGELOG.md#0190-2024-06-20), breaking the site build:

```console
$ zola build
Building site...
Error: Failed to build the site
Error: TOML parse error at line 13, column 1
   |
13 | generate_feed = true
   | ^^^^^^^^^^^^^
unknown field `generate_feed`, expected one of `base_url`, `theme`, `title`, `description`, `default_language`, `languages`, `translations`, `generate_feeds`, `feed_limit`, `feed_filenames`, `hard_link_static`, `taxonomies`, `author`, `compile_sass`, `minify_html`, `build_search_index`, `ignored_content`, `ignored_static`, `mode`, `output_dir`, `preserve_dotfiles_in_output`, `link_checker`, `slugify`, `search`, `markdown`, `extra`, `generate_sitemap`, `generate_robots_txt`
```

This PR renames the option in `config.toml` to match the new name, which fixes the problem.