### PR TITLE
.github: Don’t run the `deploy` job in forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    if: ${{ !github.event.repository.fork }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Every time I sync the `main` branch in my fork with upstream’s `main`, the `deploy` workflow runs, tries to deploy the website, and rightfully fails. I can [disable the workflow](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows) manually in my fork, but I figured a little condition in the `deploy` job description is a better solution and it might prevent this from happening for others.